### PR TITLE
Ruby 3: Fix "wrong number of arguments (given 1, expected 0)"

### DIFF
--- a/lib/active_scaffold/extensions/unsaved_record.rb
+++ b/lib/active_scaffold/extensions/unsaved_record.rb
@@ -11,7 +11,7 @@ module ActiveScaffold::UnsavedRecord
   end
 
   # automatically unsets the unsaved flag
-  def save(*)
+  ruby2_keywords def save(*)
     super.tap { self.unsaved = false }
   end
 


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/